### PR TITLE
Python refactor: replace caching with --oval-file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,8 @@ venv.bak/
 
 #snapcraft
 *.snap
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class

--- a/cvescan/__main__.py
+++ b/cvescan/__main__.py
@@ -73,7 +73,7 @@ def bz2decompress(bz2_archive, target):
 
 def parse_args():
     # TODO: Consider a more flexible solution than storing this in code (e.g. config file or launchpad query)
-    acceptable_codenames = ["xenial","bionic","disco","eoan","focal"]
+    acceptable_codenames = ["xenial","bionic","eoan","focal"]
 
     cvescan_ap = ap.ArgumentParser(description=const.CVESCAN_DESCRIPTION, formatter_class=ap.RawTextHelpFormatter)
     cvescan_ap.add_argument("-c", "--cve", metavar="CVE-IDENTIFIER", help=const.CVE_HELP)

--- a/cvescan/__main__.py
+++ b/cvescan/__main__.py
@@ -79,6 +79,7 @@ def parse_args():
     cvescan_ap.add_argument("-c", "--cve", metavar="CVE-IDENTIFIER", help=const.CVE_HELP)
     cvescan_ap.add_argument("-p", "--priority", help=const.PRIORITY_HELP, choices=["critical","high","medium","all"], default="high")
     cvescan_ap.add_argument("-s", "--silent", action="store_true", default=False, help=const.SILENT_HELP)
+    cvescan_ap.add_argument("-o", "--oval-file", help=const.OVAL_FILE_HELP)
     cvescan_ap.add_argument("-m", "--manifest", help=const.MANIFEST_HELP,choices=acceptable_codenames)
     cvescan_ap.add_argument("-f", "--file", metavar="manifest-file", help=const.FILE_HELP)
     cvescan_ap.add_argument("-n", "--nagios", action="store_true", default=False, help=const.NAGIOS_HELP)
@@ -249,7 +250,8 @@ def run_manifest_mode(opt, sysinfo):
     return run_cvescan(opt, sysinfo, package_count)
 
 def run_cvescan(opt, sysinfo, package_count):
-    retrieve_oval_file(opt.oval_base_url, opt.oval_zip, opt.oval_file)
+    if opt.download_oval_file:
+        retrieve_oval_file(opt.oval_base_url, opt.oval_zip, opt.oval_file)
 
     (cve_list_all_filtered, cve_list_fixable_filtered) = \
         scan_for_cves(opt, sysinfo)

--- a/cvescan/constants.py
+++ b/cvescan/constants.py
@@ -20,6 +20,9 @@ FILE_HELP = ("Used with '-m' option to override the default behavior. Specify\n 
         "The file needs to be readable under snap confinement.\n User's home "
         "will likely work, /tmp will likely not work.")
 
+OVAL_FILE_HELP = ("Specify an OVAL file to use instead of downloading the "
+        "latest from people.canonical.com.")
+
 NAGIOS_HELP = ("Enable Nagios mode for use with NRPE.\nTypical nagios-style "
         "\"OK|WARNING|CRITICAL|UNKNOWN\" messages\n and exit codes of 0, 1, "
         "2, or 3.\n0/OK = not vulnerable to any known and patchable CVEs of "

--- a/cvescan/constants.py
+++ b/cvescan/constants.py
@@ -32,13 +32,8 @@ NAGIOS_HELP = ("Enable Nagios mode for use with NRPE.\nTypical nagios-style "
 LIST_HELP = ("Disable links. Show only CVE IDs instead of URLs.\nDefault is to "
         "output URLs linking to the Ubuntu CVE tracker.")
 
-REUSE_HELP = ("re-use zip, oval, xml, and htm files from cached versions if "
-        "possible.\nDefault is to redownload and regenerate everything.\n"
-        "Warning: this may produce inaccurate results.")
-
 TEST_HELP = ("Test mode, use test OVAL data to validate that cvescan and oscap "
-        "are\n working as expected. In test mode, files are not downloaded.\n"
-        "In test mode, the remove and verbose options are enabled automatically.")
+        "are\n working as expected. In test mode, oval files are not downloaded.")
 
 UPDATES_HELP = ("Only show CVEs affecting packages if there is an update "
         "available.\nDefault: show only CVEs affecting this system or "

--- a/cvescan/options.py
+++ b/cvescan/options.py
@@ -10,6 +10,7 @@ FMT_EXPERIMENTAL_OPTION = "-x|--experimental"
 FMT_FILE_OPTION = "-f|--file"
 FMT_MANIFEST_OPTION = "-m|--manifest"
 FMT_NAGIOS_OPTION = "-n|--nagios"
+FMT_OVAL_FILE_OPTION = "-o|--oval_file"
 FMT_PRIORITY_OPTION = "-p|priority"
 FMT_SILENT_OPTION = "-s|--silent"
 FMT_TEST_OPTION = "-t|--test"
@@ -46,13 +47,20 @@ class Options:
             self.distrib_codename = sysinfo.distrib_codename
 
     def _set_oval_file_options(self, args, sysinfo):
-        self.oval_base_url = "https://people.canonical.com/~ubuntu-security/oval"
+        self.oval_base_url = None
+        self.download_oval_file = False
 
         if self.test_mode:
             self.oval_file = "%s/com.ubuntu.test.cve.oval.xml" % sysinfo.scriptdir
             return
 
+        if args.oval_file:
+            self.oval_file = args.oval_file
+            return
+
+        self.oval_base_url = "https://people.canonical.com/~ubuntu-security/oval"
         self.oval_file = "com.ubuntu.%s.cve.oval.xml" % self.distrib_codename
+        self.download_oval_file = True
 
         if self.manifest_mode:
             self.oval_file = "oci.%s" % self.oval_file
@@ -79,7 +87,8 @@ class Options:
 def raise_on_invalid_args(args):
     raise_on_invalid_cve(args)
     raise_on_invalid_combinations(args)
-    raise_on_invalid_manifest_file(args)
+    raise_on_missing_manifest_file(args)
+    raise_on_missing_oval_file(args)
 
 def raise_on_invalid_cve(args):
     cve_regex = r"^CVE-[0-9]{4}-[0-9]{4,}$"
@@ -131,6 +140,9 @@ def raise_on_invalid_test_options(args):
     if args.nagios:
         raise_incompatible_arguments_error(FMT_TEST_OPTION, FMT_NAGIOS_OPTION)
 
+    if args.oval_file:
+        raise_incompatible_arguments_error(FMT_TEST_OPTION, FMT_OVAL_FILE_OPTION)
+
     if args.silent:
         raise_incompatible_arguments_error(FMT_TEST_OPTION, FMT_SILENT_OPTION)
 
@@ -151,12 +163,18 @@ def raise_incompatible_arguments_error(arg1, arg2):
     raise ArgumentError("The %s and %s options are incompatible and may not " \
             "be specified together." % (arg1, arg2))
 
-def raise_on_invalid_manifest_file(args):
-    if not args.file:
+def raise_on_missing_manifest_file(args):
+    raise_on_missing_file(args.file)
+
+def raise_on_missing_oval_file(args):
+    raise_on_missing_file(args.oval_file)
+
+def raise_on_missing_file(file_path):
+    if not file_path:
         return
 
-    file_abs_path = os.path.abspath(args.file)
+    file_abs_path = os.path.abspath(file_path)
     if not os.path.isfile(file_abs_path):
         # TODO: mention snap confinement in error message
-        raise ArgumentError("Cannot find manifest file \"%s\". Current "
+        raise ArgumentError("Cannot find file \"%s\". Current "
                 "working directory is \"%s\"." % (file_abs_path, os.getcwd()))

--- a/cvescan/options.py
+++ b/cvescan/options.py
@@ -11,7 +11,6 @@ FMT_FILE_OPTION = "-f|--file"
 FMT_MANIFEST_OPTION = "-m|--manifest"
 FMT_NAGIOS_OPTION = "-n|--nagios"
 FMT_PRIORITY_OPTION = "-p|priority"
-FMT_REUSE_OPTION = "-r|--reuse"
 FMT_SILENT_OPTION = "-s|--silent"
 FMT_TEST_OPTION = "-t|--test"
 FMT_UPDATES_OPTION = "-u|--updates"
@@ -26,7 +25,6 @@ class Options:
         self._set_distrib_codename(args, sysinfo)
         self._set_oval_file_options(args, sysinfo)
         self._set_manifest_file_options(args)
-        self._set_remove_cached_files_options(args)
         self._set_output_verbosity(args)
 
         self.cve = args.cve
@@ -69,9 +67,6 @@ class Options:
         self.manifest_file = os.path.abspath(args.file) if args.file else None
         self.manifest_url = MANIFEST_URL_TEMPLATE % (self.distrib_codename, self.distrib_codename)
 
-    def _set_remove_cached_files_options(self, args):
-        self.remove = (not args.reuse) or args.manifest
-
     def _set_output_verbosity(self, args):
         self.verbose_oscap_options = ""
 
@@ -96,9 +91,6 @@ def raise_on_invalid_combinations(args):
     raise_on_invalid_silent_options(args)
 
 def raise_on_invalid_manifest_options(args):
-    if args.manifest and args.reuse:
-        raise_incompatible_arguments_error(FMT_MANIFEST_OPTION, FMT_REUSE_OPTION)
-
     if args.manifest and args.test:
         raise_incompatible_arguments_error(FMT_MANIFEST_OPTION, FMT_TEST_OPTION)
 
@@ -136,9 +128,6 @@ def raise_on_invalid_test_options(args):
 
     if args.nagios:
         raise_incompatible_arguments_error(FMT_TEST_OPTION, FMT_NAGIOS_OPTION)
-
-    if args.reuse:
-        raise_incompatible_arguments_error(FMT_TEST_OPTION, FMT_REUSE_OPTION)
 
     if args.silent:
         raise_incompatible_arguments_error(FMT_TEST_OPTION, FMT_SILENT_OPTION)

--- a/cvescan/options.py
+++ b/cvescan/options.py
@@ -64,8 +64,10 @@ class Options:
         self.oval_zip = "%s.bz2" % self.oval_file
 
     def _set_manifest_file_options(self, args):
+        manifest_url_tmp = MANIFEST_URL_TEMPLATE % (self.distrib_codename, self.distrib_codename)
+
         self.manifest_file = os.path.abspath(args.file) if args.file else None
-        self.manifest_url = MANIFEST_URL_TEMPLATE % (self.distrib_codename, self.distrib_codename)
+        self.manifest_url = manifest_url_tmp if (self.manifest_mode and not args.file) else None
 
     def _set_output_verbosity(self, args):
         self.verbose_oscap_options = ""

--- a/cvescan/sysinfo.py
+++ b/cvescan/sysinfo.py
@@ -2,7 +2,6 @@ import configparser
 import math
 import os
 import sys
-import time
 
 class SysInfo:
     def __init__(self, logger):
@@ -14,7 +13,6 @@ class SysInfo:
 
         self._set_snap_info()
         self.distrib_codename = self.get_ubuntu_codename()
-        self.process_start_time = math.trunc(time.time())
         # TODO: Find a better way to do this or at least check the return code
         self.package_count = int(os.popen("dpkg -l | grep -E -c '^ii'").read())
 


### PR DESCRIPTION
This merge replaces the caching functionality with an option that allows the user to specify a local OVAL file in lieu of downloading a fresh one.

The file caching feature, invoked by using the --reuse option, provides little value to the user and adds complexity to the code. The value that the --reuse option provided was that it allowed the user to skip downloading a new OVAL file. This use case is now satisfied by the --oval-file option.

