### PR TITLE
allow os-independent development and execution, fix silent logging

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,6 @@
 [settings]
 filter_files=True
 include_trailing_comma=True
-known_third_party = conftest,lsb_release,pydpkg,pytest,setuptools,tabulate,ust_download_cache,validators,vistir
+known_third_party = conftest,pydpkg,pytest,setuptools,tabulate,ust_download_cache,validators,vistir
 line_length = 88
 multi_line_output = 3

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,6 @@
 [settings]
 filter_files=True
 include_trailing_comma=True
-known_third_party = apt_pkg,conftest,lsb_release,pytest,setuptools,tabulate,ust_download_cache,validators,vistir
+known_third_party = conftest,lsb_release,pydpkg,pytest,setuptools,tabulate,ust_download_cache,validators,vistir
 line_length = 88
 multi_line_output = 3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,8 @@ os: linux
 dist: focal
 python:
     - "3.8"
-virtualenv:
-    # This is needed because lsb-release is not installable via pip at the moment.
-    # This means that on bionic we can only test with python v3.6 or python v3.8 on focal.
-    system_site_packages: true
 before_install:
-    - sudo apt-get install -y libssl-dev libcurl4-openssl-dev lsb-release
+    - sudo apt-get install -y libssl-dev libcurl4-openssl-dev
     - pip install codecov
     - pip install pytest-cov
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,11 @@ dist: focal
 python:
     - "3.8"
 virtualenv:
-    # This is needed because lsb-release and python3-apt are not installable via
-    # pip at the moment. This means that on bionic we can only test with python
-    # v3.6 or python v3.8 on focal
+    # This is needed because lsb-release is not installable via pip at the moment.
+    # This means that on bionic we can only test with python v3.6 or python v3.8 on focal.
     system_site_packages: true
 before_install:
-    - sudo apt-get install -y libssl-dev libcurl4-openssl-dev python3-apt lsb-release
+    - sudo apt-get install -y libssl-dev libcurl4-openssl-dev lsb-release
     - pip install codecov
     - pip install pytest-cov
 install:

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The recommended way to install CVEScan is with `sudo snap install cvescan`
 The following commands will install and run CVEScan from source:
 
 ```
-$> sudo apt install python3-apt python3-pip
+$> sudo apt install python3-pip
 $> git clone https://github.com/canonical/sec-cvescan
 $> pip3 install --user sec-cvescan/
 $> ~/.local/bin/cvescan
@@ -180,7 +180,6 @@ $> ~/.local/bin/cvescan
 The following commands will install and run CVEScan from source in a virtualenv:
 
 ```
-$> sudo apt build-dep python3-apt
 $> sudo apt install python3-pip git
 $> pip3 install --user virtualenv
 $> git clone https://github.com/canonical/sec-cvescan

--- a/cvescan/__main__.py
+++ b/cvescan/__main__.py
@@ -193,6 +193,7 @@ def set_output_verbosity(opt):
 
 def get_null_logger():
     logger = logging.getLogger(const.NULL_LOGGER_NAME)
+    logger.propagate = False
     if not logger.hasHandlers():
         logger.addHandler(logging.NullHandler())
 

--- a/cvescan/cvescanner.py
+++ b/cvescan/cvescanner.py
@@ -1,4 +1,4 @@
-import apt_pkg
+from pydpkg import Dpkg
 
 import cvescan.constants as const
 from cvescan.scan_result import ScanResult
@@ -6,8 +6,6 @@ from cvescan.scan_result import ScanResult
 
 class CVEScanner:
     def __init__(self, logger):
-        apt_pkg.init_system()
-
         self.logger = logger
 
     def scan(self, codename, uct_data, installed_pkgs):
@@ -76,6 +74,6 @@ class CVEScanner:
         return binary_statuses
 
     def _installed_pkg_is_patched(self, installed_version, patched_version):
-        version_compare = apt_pkg.version_compare(installed_version, patched_version)
+        version_compare = Dpkg.compare_versions(installed_version, patched_version)
 
         return version_compare >= 0

--- a/setup.py
+++ b/setup.py
@@ -29,19 +29,12 @@ setuptools.setup(
         "Topic :: Security",
     ],
     install_requires=[
+        "pydpkg",
         "tabulate",
         "ust-download-cache",
         "vistir[spinner]",
         "validators",
     ],
-    extras_require={
-        "apt": [
-            "python-distutils-extra @ "
-            "git+https://salsa.debian.org/python-team/modules/"
-            "python-distutils-extra.git",
-            "python-apt @ git+https://salsa.debian.org/apt-team/python-apt",
-        ],
-    },
     python_requires=">=3.7",
     setup_requires=["pytest-runner"],
     tests_require=["pytest", "pytest-cov"],

--- a/tests/assets/syslibs/lsb_release.py
+++ b/tests/assets/syslibs/lsb_release.py
@@ -1,0 +1,2 @@
+def get_distro_information(*args, **kwargs):
+    pass

--- a/tests/test_local_sysinfo.py
+++ b/tests/test_local_sysinfo.py
@@ -3,7 +3,6 @@ import os
 import sys
 from unittest.mock import MagicMock
 
-import lsb_release
 import pytest
 
 import cvescan.constants as const
@@ -27,6 +26,7 @@ DEFAULT_INSTALLED_PKGS = {
     "akonadi-server": "4:19.04.3-0ubuntu3",
     "akregator": "4:19.04.3-0ubuntu1",
 }
+sys.path.append("tests/assets/syslibs")
 
 
 class MockResponses:
@@ -50,6 +50,8 @@ def apply_mock_responses(monkeypatch, mock_responses):
         monkeypatch.delenv("SNAP_USER_COMMON", raising=False)
     else:
         monkeypatch.setenv("SNAP_USER_COMMON", mock_responses.environ_snap_user_common)
+
+    import lsb_release
 
     if mock_responses.get_distro_information_raises is True:
         monkeypatch.setattr(lsb_release, "get_distro_information", raise_mock_exception)


### PR DESCRIPTION
Having `python-apt` as a dependency can result in this tool being tricky to get running in most places (sometimes even on Ubuntu systems). Since the package was only employed to compare Debian package version strings, I think it could a reasonable thing to have a pure Python implementation doing it, and `pydpkg` seems to be able to provide just that.

In doing this, I also fixed a couple other things in the tests:
* Made them independent from os-specific modules, i.e. `lsb_release`.
* Fixed "silent logging" test case as `.hasHandlers()` checks for handlers in all the logging hierarchy (same goes for most methods in the `logging` module), so if the root logger was already set up the `NullHandler` would not be added. Setting the `propagate` property to `False` will isolate the child logger from its parent and avoid that behaviour.