### PR TITLE
Add possibility to read dpkg manifest from stdin

### DIFF
--- a/cvescan/constants.py
+++ b/cvescan/constants.py
@@ -1,7 +1,7 @@
 CVESCAN_DESCRIPTION = "Scan an Ubuntu system for known vulnerabilities"
 
 VERSION_ARG_NAME = "version"
-VERSION_HELP = "Show CVEScan's version number and exit"
+VERSION_HELP = "show CVEScan's version number and exit"
 
 VERBOSE_ARG_NAME = "verbose"
 VERBOSE_HELP = "enable verbose messages"
@@ -12,7 +12,7 @@ PRIORITY_HELP = "filter output by CVE priority"
 
 DB_ARG_NAME = "db"
 DB_FILE_HELP = (
-    "Specify an Ubuntu vulnerability datbase file to use instead of downloading the"
+    "specify an Ubuntu vulnerability datbase file to use instead of downloading the"
     "  latest from people.canonical.com."
 )
 

--- a/cvescan/constants.py
+++ b/cvescan/constants.py
@@ -17,7 +17,8 @@ DB_FILE_HELP = (
 )
 
 MANIFEST_ARG_NAME = "manifest"
-MANIFEST_HELP = "scan a package manifest file instead of the local system"
+MANIFEST_STDIN_FLAG = "-"
+MANIFEST_HELP = f"scan a package manifest file instead of the local system (use '{MANIFEST_STDIN_FLAG}' to read from stdin)"
 
 CSV_ARG_NAME = "csv"
 CSV_HELP = "format output as CSV"

--- a/cvescan/dpkg_parser.py
+++ b/cvescan/dpkg_parser.py
@@ -6,10 +6,10 @@ from cvescan.errors import PkgCountError
 INSTALLED_REGEX = re.compile(r"^[uihrp]i")
 
 
-def get_installed_pkgs_from_manifest(manifest):
+def get_installed_pkgs_from_manifest(manifest_fp):
     installed_pkgs = {}
-    for pkg in manifest.splitlines():
-        (pkg, version) = pkg.split("\t")
+    for pkg in manifest_fp:
+        (pkg, version) = pkg.strip().split("\t")
         pkg = _strip_architecture_extension(pkg)
         installed_pkgs[pkg] = version
 

--- a/cvescan/manifest_parser.py
+++ b/cvescan/manifest_parser.py
@@ -1,17 +1,22 @@
+import io
 import re
+from contextlib import nullcontext
 
 import cvescan.dpkg_parser as dpkg_parser
 
 
-def parse_manifest_file(manifest_file_path):
+def parse_manifest_file(manifest_file):
     try:
-        with open(manifest_file_path, "r") as mfp:
-            manifest = mfp.read()
-
-        installed_pkgs = dpkg_parser.get_installed_pkgs_from_manifest(manifest)
+        manifest_file_context = (
+            nullcontext(manifest_file)
+            if isinstance(manifest_file, io.TextIOBase)
+            else open(manifest_file, "r")
+        )
+        with manifest_file_context as manifest:
+            installed_pkgs = dpkg_parser.get_installed_pkgs_from_manifest(manifest)
     except Exception as e:
         raise Exception(
-            "Failed to parse installed files from manifest the provided file: %s" % e
+            "Failed to parse installed files from manifest the provided input: %s" % e
         )
 
     return (installed_pkgs, _get_codename(installed_pkgs))

--- a/cvescan/options.py
+++ b/cvescan/options.py
@@ -1,8 +1,10 @@
 import os
 import re
+import sys
 
 import validators
 
+import cvescan.constants as const
 from cvescan.arg_compatibility_map import arg_compatibility_map
 from cvescan.errors import ArgumentError
 
@@ -45,7 +47,12 @@ class Options:
             self.db_file = "uct.json"
 
     def _set_manifest_file_options(self, args):
-        self.manifest_file = os.path.abspath(args.manifest) if args.manifest else None
+        if args.manifest == const.MANIFEST_STDIN_FLAG:
+            self.manifest_file = sys.stdin
+        elif args.manifest:
+            self.manifest_file = os.path.abspath(args.manifest)
+        else:
+            self.manifest_file = None
 
     def _set_syslog_options(self, args):
         self.syslog = args.syslog is not None
@@ -109,7 +116,8 @@ def raise_on_invalid_cve(args):
 
 
 def raise_on_missing_manifest_file(args):
-    raise_on_missing_file(args.manifest)
+    if args.manifest != const.MANIFEST_STDIN_FLAG:
+        raise_on_missing_file(args.manifest)
 
 
 def raise_on_missing_db_file(args):

--- a/tests/test_dpkg_parser.py
+++ b/tests/test_dpkg_parser.py
@@ -89,9 +89,7 @@ def test_installed_pkgs_dpkg_list(monkeypatch, null_logger):
 
 def test_parse_manifest_installed_pkgs():
     with open(TEST_MANIFEST_FILE % "bionic") as f:
-        manifest = f.read()
-
-    installed_pkgs = dpkg_parser.get_installed_pkgs_from_manifest(manifest)
+        installed_pkgs = dpkg_parser.get_installed_pkgs_from_manifest(f)
 
     assert len(installed_pkgs) == 11
     assert installed_pkgs.get("accountsservice", None) == "0.6.45-1ubuntu1"

--- a/tests/test_manifest_parser.py
+++ b/tests/test_manifest_parser.py
@@ -5,9 +5,7 @@ import cvescan.manifest_parser as mp
 TEST_MANIFEST_FILE = "tests/assets/manifests/%s.manifest"
 
 
-def test_parse_manifest_installed_pkgs():
-    (installed_pkgs, _) = mp.parse_manifest_file(TEST_MANIFEST_FILE % "bionic")
-
+def assert_test_bionic_manifest_packages(installed_pkgs):
     assert len(installed_pkgs) == 11
     assert installed_pkgs.get("accountsservice", None) == "0.6.45-1ubuntu1"
     assert installed_pkgs.get("acl", None) == "2.2.52-3build1"
@@ -20,6 +18,17 @@ def test_parse_manifest_installed_pkgs():
     assert installed_pkgs.get("base-files", None) == "10.1ubuntu2.8"
     assert installed_pkgs.get("python3-gdbm", None) == "3.6.9-1~18.04"
     assert installed_pkgs.get("update-manager-core", None) == "1:18.04.11.12"
+
+
+def test_parse_manifest_installed_pkgs():
+    (installed_pkgs, _) = mp.parse_manifest_file(TEST_MANIFEST_FILE % "bionic")
+    assert_test_bionic_manifest_packages(installed_pkgs)
+
+
+def test_parse_manifest_file_handle():
+    with open(TEST_MANIFEST_FILE % "bionic") as f:
+        (installed_pkgs, _) = mp.parse_manifest_file(f)
+    assert_test_bionic_manifest_packages(installed_pkgs)
 
 
 def test_parse_manifest_codename_trusty():

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,7 +1,9 @@
+import io
 import os
 
 import pytest
 
+import cvescan.constants as const
 from cvescan.errors import ArgumentError
 from cvescan.options import Options
 
@@ -211,6 +213,14 @@ def test_set_manifest_file_abspath(monkeypatch, mock_args):
     opt = Options(mock_args)
 
     assert opt.manifest_file == "/tmp/testmanifest"
+
+
+def test_set_manifest_file_stdin(monkeypatch, mock_args):
+    mock_stdin = io.StringIO()
+    monkeypatch.setattr("sys.stdin", mock_stdin)
+    mock_args.manifest = const.MANIFEST_STDIN_FLAG
+    opt = Options(mock_args)
+    assert opt.manifest_file == mock_stdin
 
 
 def test_set_cve_default(mock_args):


### PR DESCRIPTION
This change extends the `--manifest` option to accept the special value `-` and read the package manifest data from standard input (convention also used by other unix utilities). To better support this, a couple of changes were also made in downstream methods, most significantly now `get_installed_pkgs_from_manifest` accepts a file pointer rather than a string blob.
Since the on the `v3.0.0` branch the minimum supported Python version is 3.7, I took the liberty to use [the new `nullcontext` context manager](https://docs.python.org/3/library/contextlib.html#contextlib.nullcontext) to create a cleaner abstraction. If you feel this change should be made compatible with previous versions as well I can find a more widely supported alternative.
This partially solves the problems highlighted in issue #12.
 