### PR TITLE
[WIP] Add support for manually specifying manifest's codename

### DIFF
--- a/cvescan/__main__.py
+++ b/cvescan/__main__.py
@@ -110,6 +110,12 @@ def parse_args():
         default=False,
         help=const.EXPERIMENTAL_HELP,
     )
+    cvescan_ap.add_argument(
+        "--manifest-codename",
+        action="store",
+        default=None,
+        help=const.MANIFEST_CODENAME_HELP,
+    )
 
     return cvescan_ap.parse_args()
 

--- a/cvescan/constants.py
+++ b/cvescan/constants.py
@@ -59,6 +59,7 @@ EXPERIMENTAL_HELP = (
     "package updates available for users of Ubuntu Advantage running systems \n"
     "with ESM Apps and ESM Infra enabled."
 )
+MANIFEST_CODENAME_HELP = "Explicitly specify the release codename for supplied manifest. Argument is ignored when `--manifest` is not supplied"
 
 JSON_HELP = "Format output as JSON."
 

--- a/cvescan/manifest_parser.py
+++ b/cvescan/manifest_parser.py
@@ -3,7 +3,7 @@ import re
 import cvescan.dpkg_parser as dpkg_parser
 
 
-def parse_manifest_file(manifest_file_path):
+def parse_manifest_file(manifest_file_path, codename=None):
     try:
         with open(manifest_file_path) as mfp:
             manifest = mfp.read()
@@ -14,7 +14,10 @@ def parse_manifest_file(manifest_file_path):
             "Failed to parse installed files from manifest the provided file: %s" % e
         )
 
-    return (installed_pkgs, _get_codename(installed_pkgs))
+    if not codename:
+        codename = _get_codename(installed_pkgs)
+
+    return (installed_pkgs, codename)
 
 
 # This function uses a hack to guess the ubuntu release codename based on the

--- a/cvescan/options.py
+++ b/cvescan/options.py
@@ -53,6 +53,7 @@ class Options:
 
     def _set_manifest_file_options(self, args):
         self.manifest_file = os.path.abspath(args.manifest) if args.manifest else None
+        self.manifest_codename = args.manifest_codename
 
 
 def raise_on_invalid_args(args):

--- a/cvescan/target_sysinfo.py
+++ b/cvescan/target_sysinfo.py
@@ -10,7 +10,8 @@ class TargetSysInfo:
 
     def _set_from_manifest_file(self, opt):
         (installed_pkgs, codename) = manifest_parser.parse_manifest_file(
-            opt.manifest_file
+            opt.manifest_file,
+            opt.manifest_codename
         )
 
         self.installed_pkgs = installed_pkgs


### PR DESCRIPTION
Manifests that I've been attempting to parse do not have the package `update-manager-core` which is used to heuristically determine which Ubuntu release the manifest is for:

```
# cvescan -m /code/itest/data/manifest.txt
Error: An unexpected error occurred while running CVEScan: Failed to determine ubuntu release codename from the provided manifest file: Could not match version to a supported release.
```

This change adds support for manually specifying the release, e.g.:

```
# cvescan -m /code/itest/data/manifest.txt --manifest-codename xenial
```

This pull request is primarily to get feedback on the approach - if you are happy with the interface and implementation, I will add in the tests and also go back and ensure that the code passes the pre-commit hooks (due to `python3-apt` and the idiosyncracies of `--system-site-packages` the virtualenv requires a little more frobbing on older LTS)