### PR TITLE
Add -X/--exclude-cve option to ignore specific CVEs

### DIFF
--- a/cvescan/__main__.py
+++ b/cvescan/__main__.py
@@ -69,6 +69,12 @@ def main():
     download_cache = USTDownloadCache(logger)
     uct_data = load_uct_data(opt, download_cache, target_sysinfo)
 
+    for cve in opt.exclude_cve:
+        try:
+            uct_data.pop(cve)
+        except KeyError:
+            logger.warning(f"CVE not found in database: {cve}")
+
     scan_results = run_scan(target_sysinfo, uct_data, logger)
 
     output_formatter = load_output_formatter(opt, logger)
@@ -159,6 +165,12 @@ def parse_args():
     )
     cvescan_ap.add_argument(
         "-c", f"--{const.CVE_ARG_NAME}", metavar="CVE-IDENTIFIER", help=const.CVE_HELP
+    )
+    cvescan_ap.add_argument(
+        "-X", f"--{const.EXCLUDE_CVE_ARG_NAME}", metavar="CVE-EXCLUDE", help=const.EXCLUDE_CVE_HELP,
+        action="append",
+        dest="exclude_cve",
+        default=[],
     )
     cvescan_ap.add_argument(
         "-s",

--- a/cvescan/arg_compatibility_map.py
+++ b/cvescan/arg_compatibility_map.py
@@ -13,6 +13,7 @@ UNRESOLVED_FLAGS = "--unresolved"
 EXPERIMENTAL_FLAGS = "-x|--experimental"
 NAGIOS_FLAGS = "-n|--nagios"
 CVE_FLAGS = "-c|--cve"
+EXCLUDE_CVE_FLAGS = "-X|--exclude-cve"
 SILENT_FLAGS = "-s|--silent"
 
 
@@ -136,5 +137,10 @@ arg_compatibility_map = {
             const.NAGIOS_ARG_NAME,
             const.VERBOSE_ARG_NAME,
         },
+    },
+    const.EXCLUDE_CVE_ARG_NAME: {
+        "flags": EXCLUDE_CVE_FLAGS,
+        "required": set(),
+        "incompatible": set(),
     },
 }

--- a/cvescan/constants.py
+++ b/cvescan/constants.py
@@ -55,6 +55,8 @@ CVE_HELP = "report whether or not this system is vulnerable to a specific CVE."
 SILENT_ARG_NAME = "silent"
 SILENT_HELP = "do not print any output (only used with --cve)"
 
+EXCLUDE_CVE_ARG_NAME = "exclude-cve"
+EXCLUDE_CVE_HELP = "exclude reports for specific CVEs."
 
 DEBUG_LOG = "debug.log"
 LSB_RELEASE_FILE = "/etc/lsb-release"

--- a/cvescan/options.py
+++ b/cvescan/options.py
@@ -25,6 +25,7 @@ class Options:
         self.json = args.json
         self.priority = args.priority if args.priority else "high"
         self.unresolved = args.unresolved
+        self.exclude_cve = args.exclude_cve
 
         self.show_links = args.show_links
 


### PR DESCRIPTION
This change adds a flag letting us exclude particular CVEs. This will help us work around #81 and possibly help others work around similar issues as they pop up.  This will let us run something like the following:

```
cvescan --manifest manifest.txt --priority all -X CVE-2020-25632 -X CVE-2020-27779
```