### PR TITLE
add hirsute and impish to manifest codename detection

### DIFF
--- a/cvescan/manifest_parser.py
+++ b/cvescan/manifest_parser.py
@@ -28,6 +28,8 @@ def _get_codename(installed_pkgs):
         bionic_regex = re.compile(r"1:18.04(.\d+)+")
         focal_regex = re.compile(r"1:20.04(.\d+)+")
         groovy_regex = re.compile(r"1:20.10(.\d+)+")
+        hirsute_regex = re.compile(r"1:21.04(.\d+)+")
+        impish_regex = re.compile(r"1:21.10(.\d+)+")
 
         update_manager_core_ver = installed_pkgs.get("update-manager-core", "")
 
@@ -45,6 +47,12 @@ def _get_codename(installed_pkgs):
 
         if groovy_regex.match(update_manager_core_ver):
             return "groovy"
+
+        if hirsute_regex.match(update_manager_core_ver):
+            return "hirsute"
+
+        if impish_regex.match(update_manager_core_ver):
+            return "impish"
 
         raise Exception("Could not match version to a supported release.")
     except Exception as e:

--- a/tests/test_manifest_parser.py
+++ b/tests/test_manifest_parser.py
@@ -47,6 +47,16 @@ def test_parse_manifest_codename_groovy():
     assert codename == "groovy"
 
 
+def test_parse_manifest_codename_hirsute():
+    (_, codename) = mp.parse_manifest_file(TEST_MANIFEST_FILE % "hirsute")
+    assert codename == "hirsute"
+
+
+def test_parse_manifest_codename_impish():
+    (_, codename) = mp.parse_manifest_file(TEST_MANIFEST_FILE % "impish")
+    assert codename == "impish"
+
+
 def test_parse_manifest_codename_failure():
     with pytest.raises(Exception):
         (_, codename) = mp.parse_manifest_file(TEST_MANIFEST_FILE % "disco")


### PR DESCRIPTION
This adds support for newer Ubuntu distributions to the manifest codename detection "magic".

Not sure what the current state of this project is, but could be an easy merge? 🤷 